### PR TITLE
For Python 2.7, need to require "subprocess>=3.5".

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -134,7 +134,7 @@ setup_args['install_requires'] = [
     'jupyterlab_launcher>=0.11.2,<0.12.0',
     'ipython_genutils',
     'futures;python_version<"3.0"',
-    'subprocess32;python_version<"3.0"'
+    'subprocess32>=3.5;python_version<"3.0"'
 ]
 
 setup_args['extras_require'] = {


### PR DESCRIPTION
Due to changes in `jupyterlab_launcher`, with Python 2.7 one now needs version 3.5 of the `subprocess` module, not the previous 3.2.7.   This would fix #5129. 